### PR TITLE
update xml reader

### DIFF
--- a/fabelcommon/xmls/xml.py
+++ b/fabelcommon/xmls/xml.py
@@ -1,5 +1,6 @@
 from xml.etree.ElementTree import XMLParser
 from lxml import etree
+from lxml.etree import _Element, _ElementTree
 
 
 def read_xml_str(xml_file_name: str) -> str:
@@ -7,13 +8,13 @@ def read_xml_str(xml_file_name: str) -> str:
         return xml_file.read()
 
 
-def read_xml_etree(xml_file_name: str) -> etree:
-    tree = etree.parse(xml_file_name)
-    return tree
+def read_xml_etree(xml_file_name: str) -> _Element:
+    tree: _ElementTree = etree.parse(xml_file_name)
+    return tree.getroot()
 
 
-def xml_to_etree(xml_str: str) -> etree:
+def xml_to_etree(xml_str: str) -> _Element:
     utf8_parser: XMLParser = etree.XMLParser(encoding='utf-8')
     xml_str_as_utf8: bytes = xml_str.encode('utf-8')
-    tree: etree = etree.fromstring(xml_str_as_utf8, parser=utf8_parser)
-    return tree
+    tree_root: _Element = etree.fromstring(xml_str_as_utf8, parser=utf8_parser)
+    return tree_root


### PR DESCRIPTION
read_xml_etree and xml_to_etree had two different return types both marked 'etree' - type hints updated and return value for read_xml_etree changed to match